### PR TITLE
export createAstraUri() and fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ npm i -s astra-mongoose
 
 ```javascript
 import mongoose from 'mongoose';
-import { driver, createAstraUri } from 'astra-mongoose';
+import { driver, collections } from 'astra-mongoose';
 
 // override the default mongodb native driver
-mongoose.driver.set(astraMongooseDriver);
-mongoose.Connection = astraMongooseDriver.getConnection();
-mongoose.Collection = astraMongooseDriver.Collection;
+mongoose.driver.set(driver);
+mongoose.Connection = driver.getConnection();
+mongoose.Collection = driver.Collection;
 mongoose.connections = [new mongoose.Connection(mongoose)];
 
 // create an Astra DB URI
-const astraUri = createAstraUri(
+const astraUri = collections.createAstraUri(
   process.env.ASTRA_DB_ID,
   process.env.ASTRA_DB_REGION,
   process.env.ASTRA_DB_KEYSPACE,

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -98,9 +98,10 @@ export class HTTPClient {
 
     // set the baseURL to Astra, if the user provides a Stargate URL, use that instead.
     // databaseId and databaseRegion are required if no other URL is provided.
-    if (options.databaseId && options.databaseRegion) {
+    /*if (options.databaseId && options.databaseRegion) {
       this.baseUrl = `https://${options.astraDatabaseId}-${options.astraDatabaseRegion}.apps.astra.datastax.com`;
-    } else if (options.baseUrl) {
+    } else */
+    if (options.baseUrl) {
       this.baseUrl = options.baseUrl;
     } else {
       throw new Error('baseUrl required for initialization');

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -18,3 +18,5 @@ export { Binary, Decimal128, ObjectId, ReadPreference } from 'mongodb';
 
 // alias for MongoClient shimming
 export { Client as MongoClient } from './client';
+
+export { createAstraUri } from './utils';


### PR DESCRIPTION
I ran into a couple of issues running this locally, fixed up the README to account for that. Also `options.databaseId && options.databaseRegion` didn't compile, so I commented that out for now.